### PR TITLE
Unmoosening

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,11 +15,13 @@ WriteMakefile(
           Compress::Zlib
           CPAN::DistnameInfo
           File::Slurp
-          Moose
+          Moo
           Path::Class
           PPI
           Test::InDistDir
           Test::More
+          Type::Utils
+          Types::Standard
           version
           )
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,5 +22,16 @@ WriteMakefile(
           Test::More
           version
           )
-    }
+    },
+    META_MERGE => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url =>
+                    'https://github.com/wchristian/parse-cpan-packages.git',
+                web => 'https://github.com/wchristian/parse-cpan-packages',
+            },
+        },
+    },
 );

--- a/lib/Parse/CPAN/Packages.pm
+++ b/lib/Parse/CPAN/Packages.pm
@@ -1,23 +1,21 @@
 package Parse::CPAN::Packages;
-use Moose;
+use Moo;
 use CPAN::DistnameInfo;
 use Compress::Zlib;
 use Path::Class ();
 use File::Slurp 'read_file';
 use Parse::CPAN::Packages::Distribution;
 use Parse::CPAN::Packages::Package;
+use Types::Standard qw( HashRef Maybe Str );
 use version;
 our $VERSION = '2.38';
 
-has 'filename' => ( is => 'rw', isa => 'Str' );
-has 'mirror_dir' => ( is => 'rw', isa => 'Str|Undef', lazy_build => 1 );
-
-has 'details'     => ( is => 'rw', isa => 'HashRef', default => sub { {} } );
-has 'data'        => ( is => 'rw', isa => 'HashRef', default => sub { {} } );
-has 'dists'       => ( is => 'rw', isa => 'HashRef', default => sub { {} } );
-has 'latestdists' => ( is => 'rw', isa => 'HashRef', default => sub { {} } );
-
-__PACKAGE__->meta->make_immutable;
+has 'filename'    => ( is => 'rw', isa => Str );
+has 'mirror_dir'  => ( is => 'rw', isa => Maybe[ Str ], lazy => 1, builder => '_build_mirror_dir' );
+has 'details'     => ( is => 'rw', isa => HashRef, default => sub { {} } );
+has 'data'        => ( is => 'rw', isa => HashRef, default => sub { {} } );
+has 'dists'       => ( is => 'rw', isa => HashRef, default => sub { {} } );
+has 'latestdists' => ( is => 'rw', isa => HashRef, default => sub { {} } );
 
 sub BUILDARGS {
     my ( $class, @args ) = @_;

--- a/lib/Parse/CPAN/Packages/Distribution.pm
+++ b/lib/Parse/CPAN/Packages/Distribution.pm
@@ -1,19 +1,18 @@
 package Parse::CPAN::Packages::Distribution;
-use Moose;
+use Moo;
 use Archive::Peek;
 use Path::Class 'file';
+use Types::Standard qw( ArrayRef Maybe Str );
 
-has 'prefix'     => ( is => 'rw', isa => 'Str' );
-has 'dist'       => ( is => 'rw', isa => 'Str|Undef' );
-has 'version'    => ( is => 'rw', isa => 'Str|Undef' );
-has 'maturity'   => ( is => 'rw', isa => 'Str' );
-has 'filename'   => ( is => 'rw', isa => 'Str' );
-has 'cpanid'     => ( is => 'rw', isa => 'Str' );
-has 'distvname'  => ( is => 'rw', isa => 'Str|Undef' );
-has 'packages'   => ( is => 'rw', isa => 'ArrayRef', default => sub { [] } );
-has 'mirror_dir' => ( is => 'rw', isa => 'Str|Undef' );
-
-__PACKAGE__->meta->make_immutable;
+has 'prefix'     => ( is => 'rw', isa => Str );
+has 'dist'       => ( is => 'rw', isa => Maybe[ Str ] );
+has 'version'    => ( is => 'rw', isa => Maybe[ Str ] );
+has 'maturity'   => ( is => 'rw', isa => Str );
+has 'filename'   => ( is => 'rw', isa => Str );
+has 'cpanid'     => ( is => 'rw', isa => Str );
+has 'distvname'  => ( is => 'rw', isa => Maybe[ Str ] );
+has 'packages'   => ( is => 'rw', isa => ArrayRef, default => sub { [] } );
+has 'mirror_dir' => ( is => 'rw', isa => Maybe[ Str ] );
 
 sub contains {
     my $self = shift;

--- a/lib/Parse/CPAN/Packages/Package.pm
+++ b/lib/Parse/CPAN/Packages/Package.pm
@@ -1,12 +1,13 @@
 package Parse::CPAN::Packages::Package;
-use Moose;
+use Moo;
 
 use PPI;
+use Types::Standard qw( InstanceOf Str );
 
-has 'package'      => ( is => 'rw', isa => 'Str' );
-has 'version'      => ( is => 'rw', isa => 'Str' );
-has 'prefix'       => ( is => 'rw', isa => 'Str' );
-has 'distribution' => ( is => 'rw', isa => 'Parse::CPAN::Packages::Distribution' );
+has 'package'      => ( is => 'rw', isa => Str );
+has 'version'      => ( is => 'rw', isa => Str );
+has 'prefix'       => ( is => 'rw', isa => Str );
+has 'distribution' => ( is => 'rw', isa => InstanceOf['Parse::CPAN::Packages::Distribution'] );
 
 sub filename {
     my ( $self )     = @_;
@@ -42,8 +43,6 @@ sub has_matching_sub {
 
     return @matching_subs;
 }
-
-__PACKAGE__->meta->make_immutable;
 
 1;
 


### PR DESCRIPTION
s/Moose/Moo/

Let me know if you want any further changes.  I changed a lazy_build to a lazy + builder.  I realize that lazy_build creates some other methods as well (predicate + writer? it's removed from the docs now, so hard to tell), but I didn't see where those were being used.  If you wanted to maintain those as part of the public API, I'd need to add them as well.
