### PR TITLE
Use File::Slurper instead of File::Slurp

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
           Archive::Peek
           Compress::Zlib
           CPAN::DistnameInfo
-          File::Slurp
+          File::Slurper
           Moo
           Path::Class
           PPI

--- a/lib/Parse/CPAN/Packages.pm
+++ b/lib/Parse/CPAN/Packages.pm
@@ -3,7 +3,7 @@ use Moo;
 use CPAN::DistnameInfo;
 use Compress::Zlib;
 use Path::Class ();
-use File::Slurp 'read_file';
+use File::Slurper ();
 use Parse::CPAN::Packages::Distribution;
 use Parse::CPAN::Packages::Package;
 use Types::Standard qw( HashRef Maybe Str );
@@ -50,13 +50,11 @@ sub _slurp_details {
     return $filename if $filename =~ /Description:/;
     return Compress::Zlib::memGunzip( $filename ) if $filename =~ /^\037\213/;
 
-    my @read_params = ( $filename );
-    push @read_params, ( binmode => ':raw' ) if $filename =~ /\.gz/;
+    return Compress::Zlib::memGunzip(
+        File::Slurper::read_binary( $filename )
+    ) if $filename =~ /\.gz/;
 
-    my $data = read_file( @read_params );
-
-    return Compress::Zlib::memGunzip( $data ) if $filename =~ /\.gz/;
-    return $data;
+    return File::Slurper::read_text( $filename );
 }
 
 for my $subname ( qw(file url description columns intended_for written_by line_count last_updated) ) {

--- a/t/simple.t
+++ b/t/simple.t
@@ -2,7 +2,7 @@
 use strict;
 use Test::InDistDir;
 use Test::More;
-use File::Slurp 'read_file';
+use File::Slurper ();
 
 run();
 done_testing;
@@ -12,8 +12,8 @@ sub run {
 
     default_features();
 
-    my $raw_data = read_file( "t/02packages.details.txt" );
-    my $gz_data = read_file( "t/02packages.details.txt.gz", binmode => ':raw' );
+    my $raw_data = File::Slurper::read_text( "t/02packages.details.txt" );
+    my $gz_data = File::Slurper::read_binary( "t/02packages.details.txt.gz" );
 
     creation_check( "t/02packages.details.txt.gz", "gzip file is parsed" );
     creation_check( $raw_data,                     "text contents are parsed" );


### PR DESCRIPTION
This PR is a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/march.html).
 (link not ready yet, hopefully soon when Neil updates the site.)

This implements the suggestion in [RT#101983](https://rt.cpan.org/Public/Bug/Display.html?id=101983) switching to File::Slurper.  See also [leont's post](http://blogs.perl.org/users/leon_timmermans/2015/08/fileslurp-is-broken-and-wrong.html) for the rationale.