### PR TITLE
Add CPAN::Meta to dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile(
           Archive::Peek
           Compress::Zlib
           CPAN::DistnameInfo
+          CPAN::Meta
           File::Slurp
           Moo
           Path::Class


### PR DESCRIPTION
This PR is another submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/march.html).  (link not ready yet, hopefully soon when Neil updates the site.)

This fixes FTBFS on perl 5.12 and lower:

    % corelist CPAN::Meta

    Data for 2018-02-20
    CPAN::Meta was first released with perl v5.13.10