### PR TITLE
Use Path::Tiny::slurp instead of File::Slurp::read_file

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,9 +14,9 @@ WriteMakefile(
           Archive::Peek
           Compress::Zlib
           CPAN::DistnameInfo
-          File::Slurp
           Moo
           Path::Class
+          Path::Tiny
           PPI
           Test::InDistDir
           Test::More

--- a/lib/Parse/CPAN/Packages.pm
+++ b/lib/Parse/CPAN/Packages.pm
@@ -3,7 +3,7 @@ use Moo;
 use CPAN::DistnameInfo;
 use Compress::Zlib;
 use Path::Class ();
-use File::Slurp 'read_file';
+use Path::Tiny;
 use Parse::CPAN::Packages::Distribution;
 use Parse::CPAN::Packages::Package;
 use Types::Standard qw( HashRef Maybe Str );
@@ -50,10 +50,9 @@ sub _slurp_details {
     return $filename if $filename =~ /Description:/;
     return Compress::Zlib::memGunzip( $filename ) if $filename =~ /^\037\213/;
 
-    my @read_params = ( $filename );
-    push @read_params, ( binmode => ':raw' ) if $filename =~ /\.gz/;
-
-    my $data = read_file( @read_params );
+    my @slurp_params = ();
+    push @slurp_params, {binmode => ":raw"}  if $filename =~ /\.gz/;
+    my $data = path( $filename )->slurp( @slurp_params );
 
     return Compress::Zlib::memGunzip( $data ) if $filename =~ /\.gz/;
     return $data;

--- a/t/simple.t
+++ b/t/simple.t
@@ -2,7 +2,7 @@
 use strict;
 use Test::InDistDir;
 use Test::More;
-use File::Slurp 'read_file';
+use Path::Tiny;
 
 run();
 done_testing;
@@ -12,8 +12,8 @@ sub run {
 
     default_features();
 
-    my $raw_data = read_file( "t/02packages.details.txt" );
-    my $gz_data = read_file( "t/02packages.details.txt.gz", binmode => ':raw' );
+    my $raw_data = path( "t/02packages.details.txt" )->slurp;
+    my $gz_data  = path( "t/02packages.details.txt.gz" )->slurp( {binmode => ":raw"} );
 
     creation_check( "t/02packages.details.txt.gz", "gzip file is parsed" );
     creation_check( $raw_data,                     "text contents are parsed" );


### PR DESCRIPTION
File::Slurp::read_file() has not yet been adapted for certain
fatalizations in the core sysread function scheduled for release in
perl-5.30.0.  Path-Tiny is a better maintained CPAN distribution.
Let's use its slurp method instead.